### PR TITLE
Add Registry "bits" to support newer Windows Server versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ Salt formula to manage the configuration of the Windows Update Agent
 ### windows-update-agent
 
 Configure the registry entries associated with the Windows Update Agent.
-Microsoft describes the relevant registry entries in a [Technet article]
-(https://technet.microsoft.com/en-us/library/Dd939844(v=WS.10).aspx).
+* Microsoft describes the Server 2008 configuration-items' relevant registry
+entries in the [Configure Automatic Updates using Registry Editor](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd939844(v=ws.10))
+"previous versions" Microsoft Learn document.
+* Microsoft describes the Server 2016, 2019, 2022 and 2025 configuration-items'
+relevant registry entries in the [Configure Automatic Updates using Registry Editor](https://learn.microsoft.com/en-us/windows/deployment/update/waas-wu-settings)
+"current versions" Microsoft Learn document.
 
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ remove undefined keys, see the configuration setting
 **Example -- Utilize an internal WSUS server for updates**:
 >Note the three settings below that have defined values...
 
-```
+```yaml
 windows-update-agent:
   lookup:
     registry:
@@ -93,8 +93,34 @@ windows-update-agent:
         ScheduledInstallDay: ''
         ScheduledInstallTime: ''
         UseWUServer: '1'
+```
+
+**Example -- Utilize a the public Windows Update servers for updates**:
+
+```yaml
+windows-update-agent:
+  lookup:
+    registry:
+      'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU':
+        NoAutoUpdate: '0'
+        AUOptions: '4'
+        ScheduledInstallEveryWeek: '1'
+        ScheduledInstallDay: '0'
+        ScheduledInstallTime: '0'
+        UseWUServer: '0'
+        NoAutoRebootWithLoggedOnUsers: '1'
       'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator':
         InstallAtShutdown: '1'
         ScanBeforeInitialLogonAllowed: '1'
         UsoDisableAADJAttribution: '0'
 ```
+
+In the above:
+* The `HKLM...WindowsUpdate\AU` registry key-path defines _when_ scheduled updates are done:
+    * Use of the `ScheduledInstall*` keys are enabled by setting the `AUOptions` key's value to `4`
+    * Periodic updates are enabled via the `ScheduledInstallEveryWeek` key's (boolean) value
+    * Check-runs happen daily via the `ScheduledInstallDay` key's (numeric, `0` thorugh `7`) value
+    * Check-runs happen (relative to the system's timezone) at midnight via the `ScheduledInstallTime` key's (numeric, `0` through `23`) value
+* The `HKLM...WindowsUpdate\Orchestrator` registry key-path defines when addtional, non-scheduled updates may be done:
+    * Users are prompted to install any pending updates at shutdown via the `InstallAtShutdown` key's (boolean) value
+    * Available updates are allowed to be applied before any person ever logs into the system via the `ScanBeforeInitialLogonAllowed` key's (boolean) value

--- a/README.md
+++ b/README.md
@@ -49,11 +49,10 @@ windows-update-agent:
 
 This is a dictionary of all the registry keys and subkeys that can be
 configured by this formula. Detailed descriptions of the registry entries can
-be found in the [linked Microsoft Technet article]
-(https://technet.microsoft.com/en-us/library/Dd939844(v=WS.10).aspx). If none
-of the pillar settings have a value, by default the formula will do nothing.
-To remove undefined keys, see the configuration setting [remove-undefined-keys]
-(#windows-update-agent:remove-undefined-keys).
+be found in the previously-linked Microsoft Learn articles. If none of the
+pillar settings have a value, by default the formula will do nothing.  To
+remove undefined keys, see the configuration setting
+[remove-undefined-keys](#windows-update-agent:remove-undefined-keys).
 
 **Example -- Utilize an internal WSUS server for updates**:
 >Note the three settings below that have defined values...

--- a/README.md
+++ b/README.md
@@ -90,4 +90,8 @@ windows-update-agent:
         ScheduledInstallDay: ''
         ScheduledInstallTime: ''
         UseWUServer: '1'
+      'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator':
+        InstallAtShutdown: '1'
+        ScanBeforeInitialLogonAllowed: '1'
+        UsoDisableAADJAttribution: '0'
 ```

--- a/pillar.example
+++ b/pillar.example
@@ -17,7 +17,7 @@ windows-update-agent:
 
   # Dictionary of Windows Update registry keys and values
   registry:
-    hklm-windows-update:
+    'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate':
       AcceptTrustedPublisherCerts: ''
       DisableWindowsUpdateAccess: ''
       ElevateNonAdmins: ''
@@ -25,13 +25,13 @@ windows-update-agent:
       TargetGroupEnabled: ''
       WUServer: ''
       WUStatusServer: ''
-    hkcu-explorer:
+    'HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer':
       DisableWindowsUpdateAccess: ''
-    hklm-internet-communication:
+    'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Internet Communication Management\Internet Communication':
       NoWindowsUpdate: ''
-    hkcu-windows-update:
+    'HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\WindowsUpdate':
       DisableWindowsUpdateAccess: ''
-    hklm-windows-update-au:
+    'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\AU':
       AlwaysAutoRebootAtScheduledTime: ''
       AlwaysAutoRebootAtScheduledTimeMinutes: ''
       AUOptions: ''
@@ -49,3 +49,7 @@ windows-update-agent:
       ScheduledInstallDay: ''
       ScheduledInstallTime: ''
       UseWUServer: ''
+    'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator':
+      InstallAtShutdown: ''
+      ScanBeforeInitialLogonAllowed: ''
+      UsoDisableAADJAttribution: ''

--- a/tests/pillar/test-main/main.sls
+++ b/tests/pillar/test-main/main.sls
@@ -2,10 +2,11 @@
 # keys found in this technet article:
 # - https://technet.microsoft.com/en-us/library/Dd939844(v=WS.10).aspx
 # The formula supports all keys listed in that article under these subkeys:
-# - HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate
 # - HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer
-# - HKEY_LOCAL_MACHINE\SYSTEM\Internet Communication Management\Internet Communication
 # - HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\WindowsUpdate
+# - HKEY_LOCAL_MACHINE\SYSTEM\Internet Communication Management\Internet Communication
+# - HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator
+# - HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate
 # - HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU
 
 
@@ -46,5 +47,10 @@ windows-update-agent:
         RescheduleWaitTime: ''
         RescheduleWaitTimeEnabled: ''
         ScheduledInstallDay: ''
+        ScheduledInstallEveryWeek: ''
         ScheduledInstallTime: ''
         UseWUServer: '1'
+      'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator':
+        InstallAtShutdown: ''
+        ScanBeforeInitialLogonAllowed: ''
+        UsoDisableAADJAttribution: ''

--- a/windows-update-agent/map.jinja
+++ b/windows-update-agent/map.jinja
@@ -61,6 +61,8 @@
     vtype: REG_DWORD
   ScheduledInstallDay:
     vtype: REG_DWORD
+  ScheduledInstallEveryWeek:
+    vtype: REG_DWORD
   ScheduledInstallTime:
     vtype: REG_DWORD
   UseWUServer:

--- a/windows-update-agent/map.jinja
+++ b/windows-update-agent/map.jinja
@@ -3,6 +3,7 @@
 # Formula supports all keys under these subkeys:
 # - HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate
 # - HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU
+# - HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator
 
 {%- load_yaml as wua %}
 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate':
@@ -63,6 +64,9 @@
   ScheduledInstallTime:
     vtype: REG_DWORD
   UseWUServer:
+    vtype: REG_DWORD
+'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator':
+  ScanBeforeInitialLogonAllowed:
     vtype: REG_DWORD
 {%- endload %}
 

--- a/windows-update-agent/map.jinja
+++ b/windows-update-agent/map.jinja
@@ -68,7 +68,11 @@
   UseWUServer:
     vtype: REG_DWORD
 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator':
+  InstallAtShutdown:
+    vtype: REG_DWORD
   ScanBeforeInitialLogonAllowed:
+    vtype: REG_DWORD
+  UsoDisableAADJAttribution:
     vtype: REG_DWORD
 {%- endload %}
 

--- a/windows-update-agent/map.jinja
+++ b/windows-update-agent/map.jinja
@@ -31,11 +31,11 @@
   DisableWindowsUpdateAccess:
     vtype: REG_DWORD
 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU':
+  AUOptions:
+    vtype: REG_DWORD
   AlwaysAutoRebootAtScheduledTime:
     vtype: REG_DWORD
   AlwaysAutoRebootAtScheduledTimeMinutes:
-    vtype: REG_DWORD
-  AUOptions:
     vtype: REG_DWORD
   AutoInstallMinorUpdates:
     vtype: REG_DWORD


### PR DESCRIPTION
Closes #33 

These updates seem to set the required registry values:
<img width="1024" alt="Registry Settings" src="https://github.com/user-attachments/assets/18d78c25-4163-4825-b9b0-1d86418d0c1c" />

<img width="1024" alt="Registry Settings" src="https://github.com/user-attachments/assets/1e596557-e10b-4058-a320-04bf5bbfaa85" />


And the service seems to get started:
<img width="1024" alt="Service Status" src="https://github.com/user-attachments/assets/e57021a7-4b33-4128-8783-c5b6c183faf1" />

Currently awaiting a validation-scan before finalizing this PR.